### PR TITLE
Adds ability for predicate based trampling items

### DIFF
--- a/Common/src/main/java/net/darkhax/tramplenomore/ITrampleFootwear.java
+++ b/Common/src/main/java/net/darkhax/tramplenomore/ITrampleFootwear.java
@@ -1,0 +1,29 @@
+package net.darkhax.tramplenomore;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+
+@FunctionalInterface
+public interface ITrampleFootwear {
+
+    /**
+     * Called when an entity is about to trample farmland.
+     * @param stack The ItemStack of the footwear being worn.
+     * @param trampler The entity trampling the farmland.
+     * @param pos The position of the farmland being trampled.
+     * @param state The state of the farmland being trampled.
+     * @return returns weather the wearer should be able to cancel the trampling.
+     */
+    boolean cancelTrample(ItemStack stack, LivingEntity trampler, BlockPos pos, BlockState state);
+
+    /**
+     * A helper method to check if an item is a trampling footwear and if it should cancel the trampling.
+     * @return returns weather the trample should be canceled.
+     */
+    static boolean cancelsTrampling(ItemStack stack, LivingEntity trampler, BlockPos pos, BlockState state) {
+
+        return stack.getItem() instanceof ITrampleFootwear trampleItem && trampleItem.cancelTrample(stack, trampler, pos, state);
+    }
+}

--- a/Common/src/main/java/net/darkhax/tramplenomore/TrampleNoMoreCommon.java
+++ b/Common/src/main/java/net/darkhax/tramplenomore/TrampleNoMoreCommon.java
@@ -17,14 +17,18 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TrampleNoMoreCommon {
 
     private static final TagKey<Item> SOFT_BOOTS = Services.TAGS.itemTag(new ResourceLocation(Constants.MOD_ID, "soft_boots"));
     private static final TagKey<EntityType<?>> CANT_TRAMPLE = Services.TAGS.entityTag(new ResourceLocation(Constants.MOD_ID, "prevent_trampling"));
+    private static final Map<Item, ITrampleFootwear> TRAMPLERS = new HashMap<>();
 
     private static final Config CONFIG = Config.load(new File(Services.PLATFORM.getConfigDirectory(), Constants.MOD_ID + ".json"));
 
@@ -35,6 +39,33 @@ public class TrampleNoMoreCommon {
 
         Services.EVENTS.addFarmlandTrampleListener(TrampleNoMoreCommon::onTrampleFarmland);
         Services.EVENTS.addRecipeSyncListener(TrampleNoMoreCommon::onRecipesUpdate);
+    }
+
+    /**
+     * @param itemLike The item to register the trample footwear predicate to.
+     * @param trampler The predicate to check if the item can trample farmland.
+     * @return returns true if the item was registered, false if it was already registered.
+     */
+    public static boolean registerFootwear(ItemLike itemLike, ITrampleFootwear trampler) {
+        Item item = itemLike.asItem();
+        if (TRAMPLERS.containsKey(item)) {
+            Constants.LOG.warn("Item {} is already registered as a trampling footwear.", Registry.ITEM.getKey(item));
+            return false;
+        }
+        TRAMPLERS.put(item, trampler);
+        return true;
+    }
+
+    private static boolean cancelsTrampling(ItemStack stack, LivingEntity trampler, BlockPos pos, BlockState state) {
+        if (ITrampleFootwear.cancelsTrampling(stack, trampler, pos, state)) {
+
+            return true;
+        }
+        if (TRAMPLERS.containsKey(stack.getItem())) {
+
+            return TRAMPLERS.get(stack.getItem()).cancelTrample(stack, trampler, pos, state);
+        }
+        return false;
     }
 
     private static boolean onTrampleFarmland(Entity trampler, BlockPos pos, BlockState state) {
@@ -51,6 +82,11 @@ public class TrampleNoMoreCommon {
                 }
 
                 if (CONFIG.featherFalling && EnchantmentHelper.getItemEnchantmentLevel(Enchantments.FALL_PROTECTION, footwear) > 0) {
+
+                    return true;
+                }
+
+                if (cancelsTrampling(footwear, living, pos, state)) {
 
                     return true;
                 }


### PR DESCRIPTION
### This PR adds 2 systems very closely connected
- It first adds `ITrampleFootwear` which can be registered to an item. When farmland is about to be trampled it will check if there is an associated `ITrampleFootwear` function and will run it and check if it should trample.
-  Secondly, it allows for the implementation of `ITrampleFootwear` on the footwear item and if it is implemented it will run the check on the interface of the item.

### Use cases
- A mod developer wants it so that if Trample-No-More is installed their boots now stop trampling when the farmland is moist enough (ex. greater than 4 is moist enough for the boots to not trample).
- Another case could be a mod developer making it so when also installed their boots stop trampling but now take damage when not trampling farmland they can do that by making it so it doesn't trample but damages the itemstack in the `cancelTrample` call.
- A mod developer has powered boots and when not powered and doesn't have any energy they should still trample and when powered they should not.

#### Conclusion is this is more of a system to make it so that when the players installed the Trample-No-More mod with others the other mods can have some sort of custom interaction with them to make it a more immersive experience.
